### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ of work needs to be done first.
 Wayback is an experimental state: expect breaking changes, and lots of
 bugs.  Please submit pull requests fixing bugs instead of bug reports
 if you are able.
+
+## Installation
+Dependencies:
+- wayland (wayland-server, wayland-client, wayland-cursor, wayland-egl)
+- wayland-protocol >=1.14
+- xkbcommon
+- wlroots-0.19
+
+Building:
+```
+meson setup _build
+cd _build
+meson compile
+```
+
+Installing:
+```
+meson install
+```


### PR DESCRIPTION
May be useful to have a list of dependencies for those who want to test wayback.