### PR TITLE
meson, wayback: Update to indicate code licensed under MIT license

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('wayback', 'c',
   version: '0.1',
+  license: 'MIT',
   meson_version: '>= 0.50')
 
 add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')

--- a/wayback.c
+++ b/wayback.c
@@ -2,7 +2,7 @@
  * Wayback is essentially the tinywl compositor included in wlroots
  * but stripped down to only support an X session.
  *
- * It is licensed under CC0, which places it in the public domain.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <assert.h>


### PR DESCRIPTION
Fixes: 9347dcbbfe1a6d722bba0024908cc3b835a8b3bd ("LICENSE: use MIT")