### PR TITLE
meson: Install wayback-compositor to libexec

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,8 @@ project('wayback', 'c',
 
 add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')
 
+add_global_arguments('-DWAYBACK_COMPOSITOR_EXEC_PATH="@0@/@1@/wayback-compositor"'.format(get_option('prefix'), get_option('libexecdir')), language : 'c')
+
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')

--- a/wayback-compositor/meson.build
+++ b/wayback-compositor/meson.build
@@ -3,4 +3,5 @@ executable(
 	['wayback-compositor.c'],
 	dependencies: [wayland_server, wayland_client, wayland_cursor, wayland_egl, wayland_protos, wlroots, xkbcommon, server_protos],
 	install: true,
+	install_dir: get_option('libexecdir'),
 )

--- a/xwayback/meson.build
+++ b/xwayback/meson.build
@@ -1,4 +1,3 @@
-
 executable(
 	'Xwayback',
 	['xwayback.c'],

--- a/xwayback/xwayback.c
+++ b/xwayback/xwayback.c
@@ -251,7 +251,7 @@ int main(int argc, char* argv[]) {
 		printf("Passed descriptor xback: %s; xway: %s\n", fd_xwayback, fd_xwayland);
 		close(socket_xwayback[1]);
 		close(socket_xwayland[1]);
-		execlp("wayback-compositor", "wayback-compositor", fd_xwayback, fd_xwayland, (void *)NULL);
+		execlp(WAYBACK_COMPOSITOR_EXEC_PATH, WAYBACK_COMPOSITOR_EXEC_PATH, fd_xwayback, fd_xwayland, (void *)NULL);
 		fprintf(stderr, "ERROR: failed to launch wayback-compositor\n");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Users aren't supposed to execute wayback-compositor themselves, so libexec is a better place for it.